### PR TITLE
Improve test coverage, and add rubocop rules

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,0 +1,8 @@
+Metrics/AbcSize:
+  Max: 30
+
+Metrics/ClassLength:
+  Max: 150
+
+Metrics/MethodLength:
+  Max: 20

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,3 +3,6 @@ language: ruby
 rvm:
   - 2.5.1
 before_install: gem install bundler -v 1.16.1
+scripts:
+  - bundle exec rake test
+  - bundle exec rubocop

--- a/Gemfile
+++ b/Gemfile
@@ -4,3 +4,5 @@ git_source(:github) { |repo_name| "https://github.com/#{repo_name}" }
 
 # Specify your gem's dependencies in spectator.gemspec
 gemspec
+
+gem 'simplecov', require: false, group: :test

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -6,8 +6,30 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
+    ast (2.4.0)
+    docile (1.3.0)
+    json (2.1.0)
     minitest (5.8.5)
+    parallel (1.12.1)
+    parser (2.5.1.0)
+      ast (~> 2.4.0)
+    powerpack (0.1.1)
+    rainbow (3.0.0)
     rake (10.4.2)
+    rubocop (0.55.0)
+      parallel (~> 1.10)
+      parser (>= 2.5)
+      powerpack (~> 0.1)
+      rainbow (>= 2.2.2, < 4.0)
+      ruby-progressbar (~> 1.7)
+      unicode-display_width (~> 1.0, >= 1.0.1)
+    ruby-progressbar (1.9.0)
+    simplecov (0.16.1)
+      docile (~> 1.1)
+      json (>= 1.8, < 3)
+      simplecov-html (~> 0.10.0)
+    simplecov-html (0.10.2)
+    unicode-display_width (1.3.1)
 
 PLATFORMS
   ruby
@@ -16,6 +38,8 @@ DEPENDENCIES
   bundler (~> 1.16)
   minitest (~> 5.0)
   rake (~> 10.0)
+  rubocop (~> 0.55)
+  simplecov
   spectator-rb!
 
 BUNDLED WITH

--- a/Rakefile
+++ b/Rakefile
@@ -1,5 +1,8 @@
 require 'bundler/gem_tasks'
 require 'rake/testtask'
+require 'rubocop/rake_task'
+
+RuboCop::RakeTask.new
 
 Rake::TestTask.new(:test) do |t|
   t.libs << 'test'

--- a/lib/spectator/atomic_number.rb
+++ b/lib/spectator/atomic_number.rb
@@ -35,9 +35,11 @@ module Spectator
     end
 
     def max(value)
+      v = value.to_f
       @lock.synchronize do
-        @value = value if value > @value || @value.nan?
+        @value = v if v > @value || @value.nan?
       end
+      @value
     end
 
     def to_s

--- a/lib/spectator/meter_id.rb
+++ b/lib/spectator/meter_id.rb
@@ -26,11 +26,12 @@ module Spectator
     # lazyily compute a key to be used in hashes for efficiency
     def key
       if @key.nil?
-        hash_key = @name
+        hash_key = @name.to_s
         @key = hash_key
         keys = @tags.keys
         keys.sort
-        keys.each do |k, v|
+        keys.each do |k|
+          v = tags[k]
           hash_key += "|#{k}|#{v}"
         end
         @key = hash_key

--- a/lib/spectator/registry.rb
+++ b/lib/spectator/registry.rb
@@ -121,24 +121,28 @@ module Spectator
       @http = Http.new(registry)
     end
 
-    # Start publishing if the config is acceptable:
-    #  uri is non-nil or empty
-    def start
+    def should_start?
       if @started
         Spectator.logger.info('Ignoring start request. ' \
           'Spectator registry already started')
-        return
+        return false
       end
 
       @started = true
-
       uri = @registry.config[:uri]
-      invalid = uri.nil? || uri.empty?
-      if invalid
+      if uri.nil? || uri.empty?
         Spectator.logger.info('Ignoring start request since Spectator ' \
                                   'registry has no valid uri')
-        return
+        return false
       end
+
+      true
+    end
+
+    # Start publishing if the config is acceptable:
+    #  uri is non-nil or empty
+    def start
+      return unless should_start?
 
       Spectator.logger.info 'Starting Spectator registry'
 

--- a/spectator.gemspec
+++ b/spectator.gemspec
@@ -9,13 +9,15 @@ Gem::Specification.new do |spec|
   spec.authors       = ['Daniel Muino']
   spec.email         = ['dmuino@netflix.com']
 
-  spec.summary       = 'Simple library for instrumenting code to record dimensional time series.'
-  spec.description   = 'Library for instrumenting ruby applications, sending metrics to an Atlas
-aggregator service.'
+  spec.summary       = 'Simple library for instrumenting code to record ' \
+    'dimensional time series.'
+  spec.description   = 'Library for instrumenting ruby applications, ' \
+    'sending metrics to an Atlas aggregator service.'
   spec.homepage      = 'https://github.com/Netflix/spectator-rb'
 
-  # Prevent pushing this gem to RubyGems.org. To allow pushes either set the 'allowed_push_host'
-  # to allow pushing to a single host or delete this section to allow pushing to any host.
+  # Prevent pushing this gem to RubyGems.org. To allow pushes either
+  # set the 'allowed_push_host' to allow pushing to a single host
+  # or delete this section to allow pushing to any host.
   if spec.respond_to?(:metadata)
     spec.metadata['allowed_push_host'] = "TODO: Set to 'http://mygemserver.com'"
   else
@@ -33,4 +35,5 @@ aggregator service.'
   spec.add_development_dependency 'bundler', '~> 1.16'
   spec.add_development_dependency 'minitest', '~> 5.0'
   spec.add_development_dependency 'rake', '~> 10.0'
+  spec.add_development_dependency 'rubocop', '~> 0.55'
 end

--- a/test/count_test.rb
+++ b/test/count_test.rb
@@ -30,4 +30,9 @@ class CounterTest < Minitest::Test
     assert_equal(1, ms.size)
     assert_equal(0, ms[0].value)
   end
+
+  def test_to_s
+    expected = 'Counter{id=MeterId{name=counter, tags={}}, count=0}'
+    assert_equal(expected, @cnt.to_s)
+  end
 end

--- a/test/gauge_test.rb
+++ b/test/gauge_test.rb
@@ -30,4 +30,9 @@ class GaugeTest < Minitest::Test
     assert_equal(1, ms.size)
     assert(ms[0].value.nan?)
   end
+
+  def test_to_s
+    expected = 'Gauge{id=MeterId{name=gauge, tags={}}, value=NaN}'
+    assert_equal(expected, @gauge.to_s)
+  end
 end

--- a/test/id_test.rb
+++ b/test/id_test.rb
@@ -24,4 +24,19 @@ class IdTest < Minitest::Test
     id = Spectator::MeterId.new('name')
     assert_equal(:name, id.name)
   end
+
+  def test_key
+    tags = { key: 'foo', key2: 'foo2' }
+    id = Spectator::MeterId.new('test', tags)
+    assert_equal('test|key|foo|key2|foo2', id.key)
+    # second time should be cached
+    assert_equal('test|key|foo|key2|foo2', id.key)
+  end
+
+  def test_string
+    tags = { key: :foo, key2: :foo2 }
+    id = Spectator::MeterId.new('test', tags)
+    s = id.to_s
+    assert_equal("MeterId{name=test, tags=#{tags}}", s)
+  end
 end

--- a/test/measure_test.rb
+++ b/test/measure_test.rb
@@ -1,0 +1,30 @@
+require 'test_helper'
+
+class MeasureTest < Minitest::Test
+  def test_to_s
+    id = Spectator::MeterId.new('name')
+    m = Spectator::Measure.new(id, 42)
+
+    assert_equal("Measure{id=#{id}, value=42.0}", m.to_s)
+  end
+
+  def test_equal
+    id = Spectator::MeterId.new('name', test: 'val')
+    m1 = Spectator::Measure.new(id, 42.0)
+
+    id2 = Spectator::MeterId.new('name', 'test' => 'val')
+    m2 = Spectator::Measure.new(id2, 42)
+
+    assert_equal(m1, m2)
+  end
+
+  def test_equal_nan
+    id = Spectator::MeterId.new('name', test: 'val')
+    m1 = Spectator::Measure.new(id, Float::NAN)
+
+    id2 = Spectator::MeterId.new('name', 'test' => 'val')
+    m2 = Spectator::Measure.new(id2, Float::NAN)
+
+    assert_equal(m1, m2)
+  end
+end

--- a/test/number_test.rb
+++ b/test/number_test.rb
@@ -1,0 +1,52 @@
+require 'test_helper'
+
+class NumberTest < Minitest::Test
+  def test_getset
+    n = Spectator::AtomicNumber.new(1)
+    assert_equal(1, n.get)
+    n.set(2)
+    assert_equal(2, n.get)
+  end
+
+  def test_get_and_set
+    n = Spectator::AtomicNumber.new(0)
+    assert_equal(0, n.get)
+
+    assert_equal(0, n.get_and_set(10))
+    assert_equal(10, n.get_and_set(20))
+    assert_equal(20, n.get)
+  end
+
+  def test_get_and_add
+    n = Spectator::AtomicNumber.new(0)
+    assert_equal(0, n.get)
+
+    assert_equal(0, n.get_and_add(10))
+    assert_equal(10, n.get_and_add(20))
+    assert_equal(30, n.get)
+  end
+
+  def test_add_and_get
+    n = Spectator::AtomicNumber.new(0)
+    assert_equal(0, n.get)
+
+    assert_equal(10, n.add_and_get(10))
+    assert_equal(30, n.add_and_get(20))
+    assert_equal(30, n.get)
+  end
+
+  def test_max
+    n = Spectator::AtomicNumber.new(Float::NAN)
+    assert(n.get.nan?)
+
+    assert_equal(10, n.max(10))
+    assert_equal(10, n.max(9))
+    assert_equal(30, n.max(30))
+    assert_equal(30, n.max(Float::NAN))
+  end
+
+  def test_to_s
+    n = Spectator::AtomicNumber.new(42)
+    assert_equal('AtomicNumber{42}', n.to_s)
+  end
+end

--- a/test/test_api.rb
+++ b/test/test_api.rb
@@ -1,3 +1,7 @@
+# Simple example to verify the API is somewhat usable
+#
+# It is not executed automatically by rake
+#
 $LOAD_PATH.unshift File.expand_path('../lib', __dir__)
 
 require 'spectator'

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,4 +1,6 @@
 $LOAD_PATH.unshift File.expand_path('../lib', __dir__)
-require 'spectator'
+require 'simplecov'
+SimpleCov.start
 
+require 'spectator'
 require 'minitest/autorun'


### PR DESCRIPTION
Improving the test coverage caught a bug in the 'key' used for indexing
meter ids