### PR TITLE
Add license to gemspec

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@
 /pkg/
 /spec/reports/
 /tmp/
+*.gem

--- a/spectator.gemspec
+++ b/spectator.gemspec
@@ -8,6 +8,7 @@ Gem::Specification.new do |spec|
   spec.version       = Spectator::VERSION
   spec.authors       = ['Daniel Muino']
   spec.email         = ['dmuino@netflix.com']
+  spec.licenses      = ['Apache-2.0']
 
   spec.summary       = 'Simple library for instrumenting code to record ' \
     'dimensional time series.'


### PR DESCRIPTION
Be explicit about our license in the gemspec.

`gem build spectator.gemspec`

now builds without warnings