### PR TITLE
Fix rubocop warnings

### DIFF
--- a/lib/spectator/histogram/percentiles.rb
+++ b/lib/spectator/histogram/percentiles.rb
@@ -412,7 +412,7 @@ module Spectator
       def self.counters(registry, id, prefix)
         (0...length).map do |i|
           tags = { statistic: 'percentile',
-                   percentile: prefix + format('%04X', i) }
+                   percentile: prefix + format('%<idx>04X', idx: i) }
           counter_id = id.with_tags(tags)
           registry.counter_with_id(counter_id)
         end

--- a/lib/spectator/registry.rb
+++ b/lib/spectator/registry.rb
@@ -277,9 +277,8 @@ module Spectator
       else
         uri = @registry.config[:uri]
         if uri.nil? || uri.empty?
-          Spectator.logger.info(
-            'Ignoring sending of metrics since Spectator registry has no valid uri'
-          )
+          Spectator.logger.info('Ignoring sending of metrics ' \
+            'since Spectator registry has no valid uri')
           return
         end
 


### PR DESCRIPTION
Max line length + prefer annotated tokens